### PR TITLE
Try cloning every time  instead of relying on ENV var

### DIFF
--- a/Pod/Scripts/ArtsySetup.rb
+++ b/Pod/Scripts/ArtsySetup.rb
@@ -1,9 +1,13 @@
 #!/usr/bin/env ruby
 
+puts "Trying to clone Artsy's Private fonts, it is OK if it fails."
+
 # Artsy Staff gets the real fonts, which are kept behind closed doors.
-if ENV["ARTSY_STAFF_MEMBER"] || ENV["CI"] == "true"
+`git clone https://github.com/artsy/Artsy-UIFonts tmp_fonts`
+
+# This could fail
+if Dir.exist? "tmp_fonts"
   `rm Pod/Assets/*`
-  `git clone https://github.com/artsy/Artsy-UIFonts tmp_fonts`
   `mv tmp_fonts/Pod/Assets/* Pod/Assets`
 
   font_file = "Pod/Classes/UIFont+ArtsyFonts.m"


### PR DESCRIPTION
This means if the repo has access to `https://github.com/artsy/Artsy-UIFonts` it will use those instead of the closed ones. Leaving the access-rights to be based on GitHub - rather than out ENV var.