### PR TITLE
Change OSS font name of serif regular and italic

### DIFF
--- a/Pod/Classes/UIFont+ArtsyFonts.m
+++ b/Pod/Classes/UIFont+ArtsyFonts.m
@@ -89,7 +89,7 @@ static BOOL useClosedFonts = false;
 + (UIFont *)serifFontWithSize:(CGFloat)size
 {
     static dispatch_once_t onceToken;
-    NSString *font = useClosedFonts ? @"AGaramondPro-Regular" : @"EBGaramond08-Regular";
+    NSString *font = useClosedFonts ? @"AGaramondPro-Regular" : @"EBGaramond12-Regular";
     NSString *type = useClosedFonts ? @"otf" : @"ttf";
     return [self ar_LoadAndReturnFont:@"AGaramondPro-Regular" extension:type size:size onceToken:&onceToken fontFileName:font];
 }
@@ -97,7 +97,7 @@ static BOOL useClosedFonts = false;
 + (UIFont *)serifItalicFontWithSize:(CGFloat)size
 {
     static dispatch_once_t onceToken;
-    NSString *fontName = useClosedFonts ? @"AGaramondPro-Italic" : @"EBGaramond08-Italic";
+    NSString *fontName = useClosedFonts ? @"AGaramondPro-Italic" : @"EBGaramond12-Italic";
     NSString *type = useClosedFonts ? @"otf" : @"ttf";
     return [self ar_LoadAndReturnFont:@"AGaramondPro-Italic" extension:type size:size onceToken:&onceToken fontFileName:fontName];
 }


### PR DESCRIPTION
Fix for https://github.com/artsy/eigen/issues/2218

It seems that `EBGaramond08` only includes bold font.
To use normal weight, changed serif regular and italic font name to `EBGaramond12`.

I confirmed font name by following results.

```sh
% for file in `ls EBGaramond*`; do echo $file; mdls $file -name com_apple_ats_name_postscript; done
EBGaramond08-Italic.ttf
com_apple_ats_name_postscript = (
    "AGaramondPro-BoldItalic"
)
EBGaramond08-Regular.ttf
com_apple_ats_name_postscript = (
    "AGaramondPro-Bold"
)
EBGaramond12-Italic.ttf
com_apple_ats_name_postscript = (
    "AGaramondPro-Italic"
)
EBGaramond12-Regular.ttf
com_apple_ats_name_postscript = (
    "AGaramondPro-Regular"
)
```