### PR TITLE
Support passing in an access token to the private repo setup script

### DIFF
--- a/Artsy+UIFonts.podspec
+++ b/Artsy+UIFonts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Artsy+UIFonts"
-  s.version          = "3.1.2"
+  s.version          = "3.1.3"
   s.summary          = "The open source fonts for Artsy apps + UIFont categories."
   s.homepage         = "https://github.com/artsy/Artsy-OSSUIFonts"
   s.license          = 'Code is MIT, then custom font licenses.'

--- a/Pod/Scripts/ArtsySetup.rb
+++ b/Pod/Scripts/ArtsySetup.rb
@@ -3,7 +3,12 @@
 puts "Trying to clone Artsy's Private fonts, it is OK if it fails."
 
 # Artsy Staff gets the real fonts, which are kept behind closed doors.
-`git clone https://github.com/artsy/Artsy-UIFonts tmp_fonts`
+if ENV["GITHUB_SUBMODULES_USER"]
+  # Support passing in an ENV var with an access token for a custom user 
+  `git clone https://#{ENV["GITHUB_SUBMODULES_USER"]}@github.com/artsy/Artsy-UIFonts tmp_fonts`
+else
+  `git clone https://github.com/artsy/Artsy-UIFonts tmp_fonts`
+end
 
 # This could fail
 if Dir.exist? "tmp_fonts"


### PR DESCRIPTION
I'm assuming that travis isn't cloning our private repo correctly
See https://github.com/artsy/emission-nebula/issues/2