### PR TITLE
Fails pod install if clone of private repo fails and Hokusai is installed

### DIFF
--- a/Pod/Scripts/ArtsySetup.rb
+++ b/Pod/Scripts/ArtsySetup.rb
@@ -1,13 +1,22 @@
 #!/usr/bin/env ruby
 
-puts "Trying to clone Artsy's Private fonts, it is OK if it fails."
+puts "Trying to clone Artsy's Private fonts, it is OK if it fails for OSS contributors."
+
+def raise_if_hokusai!
+  `which hokusai`
+  if $?.exitstatus == 0
+    raise "You appear to have Hokusai installed but we couldn't access Artsy's private fonts repository. Failing pod install. Ask the #front-end-ios Slack channel for help."
+  end
+end
 
 # Artsy Staff gets the real fonts, which are kept behind closed doors.
 if ENV["GITHUB_SUBMODULES_USER"]
   # Support passing in an ENV var with an access token for a custom user
   `git clone https://#{ENV["GITHUB_SUBMODULES_USER"]}@github.com/artsy/Artsy-UIFonts tmp_fonts`
+  raise_if_hokusai! unless $?.exitstatus == 0
 else
   `git clone https://github.com/artsy/Artsy-UIFonts tmp_fonts`
+  raise_if_hokusai! unless $?.exitstatus == 0
   `git clone git@github.com:artsy/Artsy-OSSUIFonts.git tmp_fonts` unless Dir.exist? "tmp_fonts"  
 end
 

--- a/Pod/Scripts/ArtsySetup.rb
+++ b/Pod/Scripts/ArtsySetup.rb
@@ -5,7 +5,7 @@ puts "Trying to clone Artsy's Private fonts, it is OK if it fails for OSS contri
 def raise_if_hokusai!
   `which hokusai`
   if $?.exitstatus == 0
-    raise "You appear to have Hokusai installed but we couldn't access Artsy's private fonts repository. Failing pod install. Ask the #front-end-ios Slack channel for help."
+    raise "You appear to have Hokusai installed, which likely means you’re an Artsy staff member—however, we couldn't access Artsy's private fonts repository. Failing pod install. Ask the #front-end-ios Slack channel for help."
   end
 end
 


### PR DESCRIPTION
Our font pod had a strange setup. It's been the case before that Artsy staff have run `pod install` and have had the OSS fonts installed (because the clone of the private repo fails for whatever reason, maybe they use SSH instead of HTTPS git remotes, etc). The problem is that the OSS version of the fonts pod gets cached in `~/Library/Caches/CocoaPods/Pods`, so re-running `pod install` doesn't clear the cached OSS fonts.

This PR introduces a second check; when the clone of the private repo fails, we check to see if Hokusai is installed. If it is, then we `raise`. This prevents the `pod install` from completing and caching an invalid font pod. Hopefully this failing-fast will prevent Artsy staff from doing down a rabbit hole before asking for help.

Let me know what you think.